### PR TITLE
tls: set mark on outgoing packets

### DIFF
--- a/example/example.conf
+++ b/example/example.conf
@@ -27,6 +27,14 @@ remote : {
   ca_cert_file = "conf/router.crt.pem"
 }
 
+# Route settings
+route : {
+  # The mark to apply to packets tunneling traffic to the ENF. Packets
+  # with this mark should be routed through the physical network
+  # connection, not the tun device.
+  fwmark = 363
+}
+
 # Identity settings
 identity : {
   # [Optional] The IPv6 network from which to request an address.

--- a/src/enftun.c
+++ b/src/enftun.c
@@ -250,6 +250,7 @@ enftun_connect(struct enftun_context* ctx)
         goto out;
 
     if ((rc = enftun_tls_connect(&ctx->tls,
+                                 ctx->options.fwmark,
                                  ctx->options.remote_host,
                                  ctx->options.remote_port,
                                  ctx->options.remote_ca_cert_file,

--- a/src/options.c
+++ b/src/options.c
@@ -47,6 +47,8 @@ enftun_options_init(struct enftun_options* opts)
     opts->remote_host = "23.147.128.112";
     opts->remote_port = "443";
 
+    opts->fwmark = 363;
+
     return 0;
 }
 
@@ -127,6 +129,9 @@ enftun_options_parse_conf(struct enftun_options* opts)
     config_lookup_string(cfg, "remote.host", &opts->remote_host);
     config_lookup_string(cfg, "remote.port", &opts->remote_port);
     config_lookup_string(cfg, "remote.ca_cert_file", &opts->remote_ca_cert_file);
+
+    /* Route settings */
+    config_lookup_int(cfg, "route.fwmark", &opts->fwmark);
 
     /* Identity settings */
     config_lookup_string(cfg, "identity.cert_file", &opts->cert_file);

--- a/src/options.h
+++ b/src/options.h
@@ -38,6 +38,8 @@ struct enftun_options
 
     const char* cert_file;
     const char* key_file;
+
+    int fwmark;
 };
 
 int

--- a/src/tls.c
+++ b/src/tls.c
@@ -134,7 +134,7 @@ enftun_tls_handshake(struct enftun_tls* tls,
 }
 
 int
-enftun_tls_connect(struct enftun_tls* tls,
+enftun_tls_connect(struct enftun_tls* tls, int mark,
                    const char* host, const char *port,
                    const char* cacert_file,
                    const char* cert_file, const char* key_file)
@@ -166,6 +166,16 @@ enftun_tls_connect(struct enftun_tls* tls,
             enftun_log_debug("Failed to create socket: %s\n", strerror(errno));
             rc = -errno;
             continue;
+        }
+
+        if (mark > 0)
+        {
+            if ((rc = setsockopt(tls->fd, SOL_SOCKET, SO_MARK, &mark, sizeof(mark))) < 0)
+            {
+                enftun_log_debug("Failed to set mark %d: %s\n", mark, strerror(errno));
+                rc = -errno;
+                continue;
+            }
         }
 
         if ((rc = connect(tls->fd, addr->ai_addr, addr->ai_addrlen)) < 0)

--- a/src/tls.h
+++ b/src/tls.h
@@ -29,6 +29,8 @@
 
 struct enftun_tls
 {
+    int mark;           // mark to apply to tunnel packets. 0 to disable
+
     int fd;             // file descriptor for the underlying TCP socket
 
     SSL_CTX *ctx;       // the openSSL context
@@ -46,7 +48,7 @@ int
 enftun_tls_free(struct enftun_tls* tls);
 
 int
-enftun_tls_connect(struct enftun_tls* tls,
+enftun_tls_connect(struct enftun_tls* tls, int mark,
                    const char* host, const char* port,
                    const char* cacert_file,
                    const char* cert_file,


### PR DESCRIPTION
This mark can be used by the host routing policy to ensure that tunnel
packets are not routed back into the tunnel.

Fixes #12 