### PR TITLE
Accept multiple remote hosts or IP addresses

### DIFF
--- a/example/example.conf
+++ b/example/example.conf
@@ -20,8 +20,8 @@ tun : {
 
 # Remote server settings
 remote : {
-  # The hostname or IP address of the remote server.
-  host = "localhost"
+  # List of hostnames, IPv4, or IPv6 addresses of the remote server.
+  hosts = [ "localhost" ]
 
   # The listening port on the remote server.
   port = "4443"

--- a/src/config.c
+++ b/src/config.c
@@ -81,7 +81,8 @@ enftun_config_init(struct enftun_config* config)
     config->dev = "enf0";
     config->dev_node = "/dev/net/tun";
 
-    config->remote_host = "23.147.128.112";
+    config->remote_hosts = calloc(2, sizeof(char*));
+    config->remote_hosts[0] = "23.147.128.112";
     config->remote_port = "443";
 
     config->fwmark = 363;
@@ -100,6 +101,7 @@ enftun_config_free(struct enftun_config* config)
 {
     free(config->trusted_ifaces);
     free(config->prefixes);
+    free(config->remote_hosts);
     config_destroy(&config->cfg);
     CLEAR(*config);
     return 0;
@@ -146,7 +148,7 @@ enftun_config_parse(struct enftun_config* config, const char* file)
     config_lookup_string(cfg, "tun.dev_node", &config->dev_node);
 
     /* Remote settings */
-    config_lookup_string(cfg, "remote.host", &config->remote_host);
+    lookup_string_array(cfg, "remote.hosts", config->remote_hosts);
     config_lookup_string(cfg, "remote.port", &config->remote_port);
     config_lookup_string(cfg, "remote.ca_cert_file", &config->remote_ca_cert_file);
 
@@ -175,8 +177,8 @@ enftun_config_print(struct enftun_config* config, const char* key)
     else if (strcmp(key, "tun.dev_node") == 0)
         fprintf(stdout, "%s\n", config->dev_node);
     /* Remote settings */
-    else if (strcmp(key, "remote.host") == 0)
-        fprintf(stdout, "%s\n", config->remote_host);
+    else if (strcmp(key, "remote.hosts") == 0)
+        print_joined(config->remote_hosts, " ");
     else if (strcmp(key, "remote.port") == 0)
         fprintf(stdout, "%s\n", config->remote_port);
     else if (strcmp(key, "remote.port") == 0)

--- a/src/config.h
+++ b/src/config.h
@@ -34,7 +34,7 @@ struct enftun_config
     const char* dev;
     const char* dev_node;
 
-    const char* remote_host;
+    const char** remote_hosts;
     const char* remote_port;
     const char* remote_ca_cert_file;
 

--- a/src/enftun.c
+++ b/src/enftun.c
@@ -157,7 +157,7 @@ enftun_connect(struct enftun_context* ctx)
 
     if ((rc = enftun_tls_connect(&ctx->tls,
                                  ctx->config.fwmark,
-                                 ctx->config.remote_hosts[0],
+                                 ctx->config.remote_hosts,
                                  ctx->config.remote_port,
                                  ctx->config.remote_ca_cert_file,
                                  ctx->config.cert_file,

--- a/src/enftun.c
+++ b/src/enftun.c
@@ -157,7 +157,7 @@ enftun_connect(struct enftun_context* ctx)
 
     if ((rc = enftun_tls_connect(&ctx->tls,
                                  ctx->config.fwmark,
-                                 ctx->config.remote_host,
+                                 ctx->config.remote_hosts[0],
                                  ctx->config.remote_port,
                                  ctx->config.remote_ca_cert_file,
                                  ctx->config.cert_file,

--- a/src/tls.c
+++ b/src/tls.c
@@ -244,6 +244,11 @@ enftun_tls_connect(struct enftun_tls* tls, int mark,
         goto out;
 
     rc = enftun_tls_handshake(tls, cacert_file, cert_file, key_file);
+    if (rc < 0)
+    {
+        close(tls->fd);
+        tls->fd = 0;
+    }
 
  out:
     return rc;

--- a/src/tls.c
+++ b/src/tls.c
@@ -134,15 +134,59 @@ enftun_tls_handshake(struct enftun_tls* tls,
     return rc;
 }
 
-int
-enftun_tls_connect(struct enftun_tls* tls, int mark,
-                   const char* host, const char *port,
-                   const char* cacert_file,
-                   const char* cert_file, const char* key_file)
+static
+int attempt_connect_addr(int* fd, int mark, struct addrinfo* addr,
+                         const char* host, const char* port)
 {
-    struct addrinfo *addr_h, *addr, hints;
     char ip[45];
     int rc;
+
+    inet_ntop(addr->ai_family, get_sin_addr(addr), ip, sizeof(ip));
+    enftun_log_debug("Attempting to connect to %s at [%s]:%s\n", host, ip, port);
+
+    if ((*fd = socket(addr->ai_family, SOCK_STREAM, addr->ai_protocol)) < 0)
+    {
+        enftun_log_debug("Failed to create socket: %s\n", strerror(errno));
+        rc = -errno;
+        goto out;
+    }
+
+    if (mark > 0)
+    {
+        if ((rc = setsockopt(*fd, SOL_SOCKET, SO_MARK, &mark, sizeof(mark))) < 0)
+        {
+            enftun_log_debug("Failed to set mark %d: %s\n", mark, strerror(errno));
+            rc = -errno;
+            goto close_fd;
+        }
+    }
+
+    if ((rc = connect(*fd, addr->ai_addr, addr->ai_addrlen)) < 0)
+    {
+        enftun_log_debug("Failed to connect to [%s]:%s: %s\n",
+                         ip, port, strerror(errno));
+        rc = -errno;
+        goto close_fd;
+    }
+
+    enftun_log_info("Connected to [%s]:%s\n", ip, port);
+    goto out;
+
+ close_fd:
+    close(*fd);
+    *fd = 0;
+
+ out:
+    return rc;
+}
+
+static
+int
+attempt_connect_host(int* fd, int mark,
+                     const char* host, const char *port)
+{
+    int rc;
+    struct addrinfo *addr_h, *addr, hints;
 
     memset(&hints, 0, sizeof(hints));
     hints.ai_family   = AF_UNSPEC;
@@ -150,7 +194,8 @@ enftun_tls_connect(struct enftun_tls* tls, int mark,
     hints.ai_protocol = IPPROTO_TCP;
     hints.ai_flags    = AI_PASSIVE;
 
-    if ((rc = getaddrinfo(host, port, &hints, &addr_h)) < 0)
+    rc = getaddrinfo(host, port, &hints, &addr_h);
+    if (rc < 0)
     {
         enftun_log_error("Cannot resolve %s:%s: %s\n", host, port, gai_strerror(rc));
         goto out;
@@ -158,48 +203,49 @@ enftun_tls_connect(struct enftun_tls* tls, int mark,
 
     for (addr=addr_h; addr!=NULL; addr=addr->ai_next)
     {
-        inet_ntop(addr->ai_family, get_sin_addr(addr), ip, sizeof(ip));
-
-        enftun_log_debug("Attempting to connect to %s at [%s]:%s\n", host, ip, port);
-
-        if ((tls->fd = socket(addr->ai_family, SOCK_STREAM, addr->ai_protocol)) < 0)
-        {
-            enftun_log_debug("Failed to create socket: %s\n", strerror(errno));
-            rc = -errno;
-            continue;
-        }
-
-        if (mark > 0)
-        {
-            if ((rc = setsockopt(tls->fd, SOL_SOCKET, SO_MARK, &mark, sizeof(mark))) < 0)
-            {
-                enftun_log_debug("Failed to set mark %d: %s\n", mark, strerror(errno));
-                rc = -errno;
-                goto close_fd;
-            }
-        }
-
-        if ((rc = connect(tls->fd, addr->ai_addr, addr->ai_addrlen)) < 0)
-        {
-            enftun_log_debug("Failed to connect to [%s]:%s: %s\n",
-                             ip, port, strerror(errno));
-            rc = -errno;
-            goto close_fd;
-        }
-
-        enftun_log_info("Connected to [%s]:%s\n", ip, port);
-        break;
-
-    close_fd:
-            close(tls->fd);
-            tls->fd = 0;
+        rc = attempt_connect_addr(fd, mark, addr, host, port);
+        if (rc == 0)
+            break;
     }
 
-    if (rc == 0)
-        rc = enftun_tls_handshake(tls, cacert_file, cert_file, key_file);
+    freeaddrinfo(addr_h);
 
  out:
-    freeaddrinfo(addr_h);
+    return rc;
+}
+
+static
+int attempt_connect_hosts(int* fd, int mark,
+                          const char** hosts, const char *port)
+{
+    int rc;
+    const char* host;
+
+    for (host=*hosts; host!=NULL; host=*++hosts)
+    {
+        rc = attempt_connect_host(fd, mark, host, port);
+        if (rc == 0)
+            break;
+    }
+
+    return rc;
+}
+
+int
+enftun_tls_connect(struct enftun_tls* tls, int mark,
+                   const char** hosts, const char *port,
+                   const char* cacert_file,
+                   const char* cert_file, const char* key_file)
+{
+    int rc;
+
+    rc = attempt_connect_hosts(&tls->fd, mark, hosts, port);
+    if (rc < 0)
+        goto out;
+
+    rc = enftun_tls_handshake(tls, cacert_file, cert_file, key_file);
+
+ out:
     return rc;
 }
 

--- a/src/tls.h
+++ b/src/tls.h
@@ -49,7 +49,7 @@ enftun_tls_free(struct enftun_tls* tls);
 
 int
 enftun_tls_connect(struct enftun_tls* tls, int mark,
-                   const char* host, const char* port,
+                   const char** hosts, const char* port,
                    const char* cacert_file,
                    const char* cert_file,
                    const char* key_file);


### PR DESCRIPTION
The enftun should not use DNS to lookup the remote host, but instead simply connect to a specific IP. To support both IPv4 and IPv6 networks (and some forms of high-availability), the client must be able to specific multiple IP addresses for the enftun to use.

This commit changes the `remote.host` parameter to a list `remote.hosts`.  Each of these hosts or IPs are attempted in order, until one succeeds or all fail.

Closes #18 