### PR TITLE
Ability to change DAA basename 

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -101,6 +101,7 @@ enftun_config_init(struct enftun_config* config)
     config->xtt_device = "/dev/tpm0";
     config->xtt_socket_host = "localhost";
     config->xtt_socket_port = "2321";
+    config->xtt_basename = NULL;
 
     return 0;
 }
@@ -180,6 +181,7 @@ enftun_config_parse(struct enftun_config* config, const char* file)
         config_lookup_string(cfg, "identity.xtt.device", &config->xtt_device);
         config_lookup_string(cfg, "identity.xtt.socket_host", &config->xtt_socket_host);
         config_lookup_string(cfg, "identity.xtt.socket_port", &config->xtt_socket_port);
+        config_lookup_string(cfg, "identity.xtt.basename", &config->xtt_basename);
     }
 
     return 0;
@@ -232,6 +234,8 @@ enftun_config_print(struct enftun_config* config, const char* key)
         fprintf(stdout, "%s\n", config->xtt_socket_host);
     else if (strcmp(key, "identity.xtt.socket_port") == 0)
         fprintf(stdout, "%s\n", config->xtt_socket_port);
+    else if (strcmp(key, "identity.xtt.basename") == 0)
+        fprintf(stdout, "%s\n", config->xtt_basename);
     else
     {
         fprintf(stderr, "%s not found\n", key);

--- a/src/config.h
+++ b/src/config.h
@@ -52,6 +52,7 @@ struct enftun_config
     const char* xtt_device;
     const char* xtt_socket_host;
     const char* xtt_socket_port;
+    const char* xtt_basename;
 
 };
 

--- a/src/enftun.c
+++ b/src/enftun.c
@@ -170,6 +170,7 @@ enftun_provision(struct enftun_context* ctx)
                               ctx->config.xtt_socket_host,
                               ctx->config.xtt_socket_port,
                               ctx->config.remote_ca_cert_file,
+                              ctx->config.xtt_basename,
                               &xtt);
 
     if (0 != rc)

--- a/src/xtt.c
+++ b/src/xtt.c
@@ -73,7 +73,9 @@ static int initialize_certs(TSS2_TCTI_CONTEXT *tcti_context,
                             struct xtt_server_root_certificate_context* saved_cert,
                             xtt_root_certificate* root_certificate);
 
-static int initialize_daa(struct xtt_client_group_context *group_ctx, TSS2_TCTI_CONTEXT *tcti_context);
+static int initialize_daa(struct xtt_client_group_context *group_ctx,
+                          TSS2_TCTI_CONTEXT *tcti_context,
+                          const char* basename_in);
 
 static int
 read_nvram(unsigned char *out,
@@ -106,6 +108,7 @@ enftun_xtt_handshake(const char *server_ip,
                      const char *tpm_hostname_g,
                      const char *tpm_port_g,
                      const char *ca_cert_file,
+                     const char *basename,
                      struct enftun_xtt* xtt)
 {
     int init_daa_ret = -1;
@@ -170,7 +173,7 @@ enftun_xtt_handshake(const char *server_ip,
 
     // 1ii) Initialize DAA
     struct xtt_client_group_context group_ctx;
-    init_daa_ret = initialize_daa(&group_ctx, tcti_context);
+    init_daa_ret = initialize_daa(&group_ctx, tcti_context, basename);
     ret = init_daa_ret;
     if (0 != init_daa_ret) {
         enftun_log_error("Error initializing DAA context\n");
@@ -359,33 +362,46 @@ int initialize_server_id(xtt_identity_type *intended_server_id,
 }
 
 static
-int initialize_daa(struct xtt_client_group_context *group_ctx, TSS2_TCTI_CONTEXT *tcti_context)
+int initialize_daa(struct xtt_client_group_context *group_ctx,
+                   TSS2_TCTI_CONTEXT *tcti_context,
+                   const char* basename_in)
 {
     xtt_return_code_type rc = 0;
 
     // 1) Read DAA-related things in from file/TPM-NVRAM
     xtt_daa_group_pub_key_lrsw gpk = {.data = {0}};
     xtt_daa_credential_lrsw cred = {.data = {0}};
-    unsigned char basename[1024] = {0};
     uint16_t basename_len = 0;
+
+    char basename[1024] = {0};
     int nvram_ret = 0;
-    uint8_t basename_len_from_tpm = 0;
-    nvram_ret = read_nvram((unsigned char*)&basename_len_from_tpm,
-                           1,
-                           XTT_BASENAME_SIZE_HANDLE,
-                           tcti_context);
-    if (0 != nvram_ret) {
-        enftun_log_error( "Error reading basename size from TPM NVRAM\n");
-        return TPM_ERROR;
-    }
-    basename_len = basename_len_from_tpm;
-    nvram_ret = read_nvram(basename,
-                           basename_len,
-                           XTT_BASENAME_HANDLE,
-                           tcti_context);
-    if (0 != nvram_ret) {
-        enftun_log_error("Error reading basename from TPM NVRAM\n");
-        return TPM_ERROR;
+
+    if (!basename_in)
+    {
+        uint8_t basename_len_from_tpm = 0;
+        nvram_ret = read_nvram((unsigned char*)&basename_len_from_tpm,
+                               1,
+                               XTT_BASENAME_SIZE_HANDLE,
+                               tcti_context);
+        if (0 != nvram_ret) {
+            enftun_log_error( "Error reading basename size from TPM NVRAM\n");
+            return TPM_ERROR;
+        }
+        basename_len = basename_len_from_tpm;
+        nvram_ret = read_nvram(basename,
+                               basename_len,
+                               XTT_BASENAME_HANDLE,
+                               tcti_context);
+        if (0 != nvram_ret) {
+            enftun_log_error("Error reading basename from TPM NVRAM\n");
+            return TPM_ERROR;
+        }
+
+        basename_in = &basename;
+
+    } else
+    {
+        basename_len = strlen(basename_in);
     }
 
     nvram_ret = read_nvram(gpk.data,
@@ -416,7 +432,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, TSS2_TCTI_CONTEXT
     hash_ret = crypto_hash_sha256_update(&hash_state, gpk.data, sizeof(gpk));
     if (0 != hash_ret)
         return CRYPTO_HASH_ERROR;
-    hash_ret = crypto_hash_sha256_update(&hash_state, basename, basename_len);
+    hash_ret = crypto_hash_sha256_update(&hash_state, (unsigned char*)basename_in, basename_len);
     if (0 != hash_ret)
         return CRYPTO_HASH_ERROR;
     hash_ret = crypto_hash_sha256_final(&hash_state, gid.data);
@@ -427,7 +443,7 @@ int initialize_daa(struct xtt_client_group_context *group_ctx, TSS2_TCTI_CONTEXT
     rc = xtt_initialize_client_group_context_lrswTPM(group_ctx,
                                                      &gid,
                                                      &cred,
-                                                     (unsigned char*)basename,
+                                                     (unsigned char*)basename_in,
                                                      basename_len,
                                                      XTT_KEY_HANDLE,
                                                      NULL,

--- a/src/xtt.h
+++ b/src/xtt.h
@@ -53,6 +53,7 @@ enftun_xtt_handshake(const char *server_host,
                      const char *socket_host,
                      const char *socket_port,
                      const char *ca_cert_file,
+                     const char *basename,
                      struct enftun_xtt* xtt);
 
 #endif // ENFTUN_XTT_H


### PR DESCRIPTION
In order for the customer and management traffic to have their own enftun connections, and be in different DAA groups, we need the ability to change the basename. Now, we can do so by setting the basename in the config file. 