### PR TITLE
Update to accommodate for new XTT changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(BUILD_XTT)
     add_definitions(-DUSE_TPM)
     add_definitions(-DUSE_XTT)
     find_package(sodium REQUIRED QUIET 1.0.11)
-    find_package(xtt COMPONENTS tpm REQUIRED QUIET 0.9.1)
+    find_package(xtt COMPONENTS tpm REQUIRED QUIET 0.10.1)
 endif()
 
 set(ENFTUN_SRCS

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ sudo apt-get install enftun
 * [OpenSSL]() (version 1.1.0 or higher)
 * [LibUV]() (version 1.9 or higher)
 * [LibConfig]() (version 1.5 or higher)
-* [xtt](https://github.com/xaptum/xtt) (version 0.10.0 or higher)
+* [xtt](https://github.com/xaptum/xtt) (version 0.10.1 or higher)
   * If building with XTT and TPM support
 
 ### Building the Binary

--- a/src/xtt.h
+++ b/src/xtt.h
@@ -27,14 +27,9 @@
 struct enftun_xtt
 {
     const char *suitespec;
-    unsigned int tcti_context_buffer_s_len;
-    unsigned char* tcti_context_buffer_s;
+    struct xtt_tpm_context tpm_ctx;
+    struct xtt_tpm_params tpm_params;
 };
-
-typedef enum {
-    XTT_TCTI_SOCKET,
-    XTT_TCTI_DEVICE,
-} xtt_tcti_type;
 
 int
 enftun_xtt_init(struct enftun_xtt* xtt);


### PR DESCRIPTION
These changes will be necessary when XTT cuts a new release since the server_id and expiry have been taken out, and the NVRAM handles and functions for initializing the sapi and tcti contexts have been added to the XTT library. 

This fixes #44 because the xaptum-tpm updates will allow us to read variable length data from NVRAM.