### PR TITLE
Use net or netinet includes over linux

### DIFF
--- a/src/tun.c
+++ b/src/tun.c
@@ -24,9 +24,9 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 
-#include <linux/if.h>
 #include <linux/if_tun.h>
-#include <linux/ipv6.h>
+#include <net/if.h>
+#include <netinet/in.h>
 
 #include "exec.h"
 #include "ip.h"


### PR DESCRIPTION
In `tun.c`, `linux/ipv6.h` includes `linux/in6.h` which conflicts with the `netinet/in.h` included by `ip.h` so we changed both of the conflicting files to their `net/` or `netinet/` counterparts.