### PR TITLE
read full packet from TLS socket immediately

### DIFF
--- a/src/channel.h
+++ b/src/channel.h
@@ -49,6 +49,7 @@ struct enftun_channel_ops
     int  (*read)(void* ctx, struct enftun_packet* pkt);
     int  (*write)(void* ctx, struct enftun_packet* pkt);
     void (*prepare)(void* ctx, struct enftun_packet* pkt);
+    int  (*pending)(void* ctx);
 };
 
 struct enftun_channel

--- a/src/tls.c
+++ b/src/tls.c
@@ -28,7 +28,8 @@ struct enftun_channel_ops enftun_tls_ops =
 {
    .read    = (int  (*)(void*, struct enftun_packet*)) enftun_tls_read_packet,
    .write   = (int  (*)(void*, struct enftun_packet*)) enftun_tls_write_packet,
-   .prepare = (void (*)(void*, struct enftun_packet*)) enftun_tls_prepare_packet
+   .prepare = (void (*)(void*, struct enftun_packet*)) enftun_tls_prepare_packet,
+   .pending = (int  (*)(void*)) enftun_tls_pending
 };
 
 int
@@ -268,6 +269,12 @@ size_to_read(struct enftun_packet* pkt)
 
     /* read body */
     return ntohs(*(uint16_t*)pkt->data) - (pkt->size - 2);
+}
+
+int
+enftun_tls_pending(struct enftun_tls* tls)
+{
+    return SSL_pending(tls->ssl);
 }
 
 int

--- a/src/tls.h
+++ b/src/tls.h
@@ -69,6 +69,9 @@ int
 enftun_tls_write(struct enftun_tls* tls, uint8_t* buf, size_t len);
 
 int
+enftun_tls_pending(struct enftun_tls* tls);
+
+int
 enftun_tls_read_packet(struct enftun_tls* tls, struct enftun_packet* pkt);
 
 void

--- a/src/tun.c
+++ b/src/tun.c
@@ -38,7 +38,8 @@ struct enftun_channel_ops enftun_tun_ops =
 {
    .read    = (int (*)(void*, struct enftun_packet*)) enftun_tun_read_packet,
    .write   = (int (*)(void*, struct enftun_packet*)) enftun_tun_write_packet,
-   .prepare = NULL
+   .prepare = NULL,
+   .pending = NULL
 };
 
 int

--- a/test/router.py
+++ b/test/router.py
@@ -130,8 +130,9 @@ class Connection(object):
 
     def send_packet(self, ip):
         print(ip)
-        buf = bytes(ip)
-        self._sock.send(struct.pack('!H', len(buf)))
+        body = bytes(ip)
+        head = struct.pack('!H', len(body))
+        buf = head + body
         self._sock.send(buf)
 
     def handle_packet(self, ip):


### PR DESCRIPTION
This series fixes a bug where a packet received on the TLS connection was not delivered to the TUN device until a subsequent packet was received.