### PR TITLE
Add option to export IP address to file

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -88,6 +88,8 @@ enftun_config_init(struct enftun_config* config)
     config->remote_port = "443";
     config->remote_ca_cert_file = "/etc/enftun/enf.cacert.pem";
 
+    config->ip_file = NULL;
+
     config->fwmark = 363;
     config->table = 2097;
 
@@ -176,6 +178,7 @@ enftun_config_parse(struct enftun_config* config, const char* file)
     /* Identity settings */
     config_lookup_string(cfg, "identity.cert_file", &config->cert_file);
     config_lookup_string(cfg, "identity.key_file", &config->key_file);
+    config_lookup_string(cfg, "identity.ip_file", &config->ip_file);
 
     /* XTT settings */
     if (NULL != config_lookup(cfg, "identity.xtt"))
@@ -230,6 +233,8 @@ enftun_config_print(struct enftun_config* config, const char* key)
         fprintf(stdout, "%s\n", config->cert_file);
     else if (strcmp(key, "identity.key_file") == 0)
         fprintf(stdout, "%s\n", config->key_file);
+    else if (strcmp(key, "identity.ip_file") == 0)
+        fprintf(stdout, "%s\n", config->ip_file);
     /* XTT settings */
     else if (strcmp(key, "identity.xtt.enable") == 0)
         fprintf(stdout, "%d\n", config->xtt_enable);

--- a/src/config.h
+++ b/src/config.h
@@ -41,6 +41,7 @@ struct enftun_config
 
     const char* cert_file;
     const char* key_file;
+    const char* ip_file;
 
     int fwmark;
     int table;

--- a/src/context.c
+++ b/src/context.c
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+#include "context.h"
+
+#include <stdio.h>
 #include <string.h>
 
-#include "context.h"
 #include "cert.h"
 #include "log.h"
 
@@ -122,6 +124,40 @@ enftun_context_ipv6_from_cert(struct enftun_context* ctx, const char* file)
         rc = -1;
         goto out;
     }
+
+ out:
+    return rc;
+}
+
+int
+enftun_context_ipv6_write_to_file(struct enftun_context* ctx, const char* file)
+{
+    int rc;
+
+    FILE *f = fopen(file, "w");
+    if (NULL == f)
+    {
+        enftun_log_warn("Unable to open file %s\n", file);
+        rc = -1;
+        goto out;
+    }
+
+    if (fputs(ctx->ipv6_str, f) == EOF)
+    {
+        enftun_log_warn("Failed to write to file %s\n", file);
+        rc = -1;
+        goto out;
+    }
+
+    if (fputs("\n", f) == EOF)
+    {
+        enftun_log_warn("Failed to write to file %s\n", file);
+        rc = -1;
+        goto out;
+    }
+
+    fclose(f);
+    rc = 0;
 
  out:
     return rc;

--- a/src/context.h
+++ b/src/context.h
@@ -66,5 +66,8 @@ enftun_context_free(struct enftun_context* ctx);
 int
 enftun_context_ipv6_from_cert(struct enftun_context* ctx, const char* cert);
 
+int
+enftun_context_ipv6_write_to_file(struct enftun_context* ctx, const char* file);
+
 
 #endif // ENFTUN_CONTEXT_H

--- a/src/enftun.c
+++ b/src/enftun.c
@@ -222,6 +222,12 @@ enftun_connect(struct enftun_context* ctx)
     if ((rc = enftun_context_ipv6_from_cert(ctx, ctx->config.cert_file)) < 0)
         goto out;
 
+    if (ctx->config.ip_file)
+    {
+        if ((rc = enftun_context_ipv6_write_to_file(ctx, ctx->config.ip_file)) < 0)
+            goto out;
+    }
+
     if ((rc = enftun_tls_connect(&ctx->tls,
                                  ctx->config.fwmark,
                                  ctx->config.remote_hosts,


### PR DESCRIPTION
This series adds the option to write the IP address to a config-specified file.

This is helpful on the router card. Other services like Mender and captived use this address as an identifier for the card.  Exporting to a file makes it easily consumable.