### PR TITLE
Add permissions for xtt created files

### DIFF
--- a/.docker/Makefile
+++ b/.docker/Makefile
@@ -1,5 +1,5 @@
 VERSION := 0.1.0
-PREFIX  := xaptum/enftun
+PREFIX  := xaptumeng/enftun-build
 
 .DEFAULT_GOAL := all
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
   - popd
 
 script:
-  - docker run -v $(pwd):/enftun/ -d -t --name enftun xaptum/enftun:0.1.0
+  - docker run -v $(pwd):/enftun/ -d -t --name enftun xaptumeng/enftun-build:0.1.0
   - docker exec -it enftun bash -c "cd enftun && mkdir -p build"
   - docker exec -it enftun bash -c "apt-cache policy libconfig9"
   - docker exec -it enftun bash -c "cd enftun/build && cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCMAKE_C_COMPILER=${COMPILER} -DBUILD_XTT=${USE_XTT}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(BUILD_XTT)
     add_definitions(-DUSE_TPM)
     add_definitions(-DUSE_XTT)
     find_package(sodium REQUIRED QUIET 1.0.11)
-    find_package(xtt COMPONENTS tpm REQUIRED QUIET 0.10.1)
+    find_package(xtt COMPONENTS tpm REQUIRED QUIET 0.10.4)
 endif()
 
 add_compile_options(-std=c99 -Wall -Wextra -Wno-missing-field-initializers)

--- a/src/xtt.c
+++ b/src/xtt.c
@@ -173,7 +173,7 @@ enftun_xtt_handshake(const char **server_hosts,
         goto finish;
     }
 
-    ret = xtt_save_to_file(tls_root_cert, tls_len, ca_cert_file);
+    ret = xtt_save_cert_to_file(tls_root_cert, tls_len, ca_cert_file);
     if (ret < 0) {
         return SAVE_TO_FILE_ERROR;
     }
@@ -532,18 +532,14 @@ int save_credentials(struct xtt_client_handshake_context *ctx,
         enftun_log_error("Error creating X509 certificate\n");
         return CERT_CREATION_ERROR;
     }
-    write_ret = xtt_save_to_file(cert_buf, sizeof(cert_buf), longterm_cert_out_file);
+    write_ret = xtt_save_cert_to_file(cert_buf, sizeof(cert_buf), longterm_cert_out_file);
     if(write_ret < 0){
         return SAVE_TO_FILE_ERROR;
     }
 
-    unsigned char asn1_priv_buf[XTT_ASN1_PRIVATE_KEY_LENGTH] = {0};
-    if (0 != xtt_asn1_from_ecdsap256_private_key(&my_longterm_private_key, &my_longterm_key, asn1_priv_buf, sizeof(asn1_priv_buf))) {
-        enftun_log_error("Error creating ASN.1 private key\n");
-        return 1;
-    }
-    write_ret = xtt_save_to_file(asn1_priv_buf, sizeof(asn1_priv_buf), longterm_private_key_out_file);
+    write_ret = xtt_write_ecdsap256_keypair(&my_longterm_key, &my_longterm_private_key, longterm_private_key_out_file);
     if(write_ret < 0) {
+        enftun_log_error("Error creating ASN.1 private key\n");
         return SAVE_TO_FILE_ERROR;
     }
 


### PR DESCRIPTION
Update `enftun` to use `xtt` v0.10.4, so that we have explicitly set permissions for the files that xtt creates (longterm certificate and private key). The docker image was also moved from the `xaptum` repo to `xaptumeng`.

Fixes #66 