### PR TITLE
ndp: cancel outstanding crb when stopping

### DIFF
--- a/src/ndp.c
+++ b/src/ndp.c
@@ -130,6 +130,9 @@ enftun_ndp_stop(struct enftun_ndp* ndp)
 {
     uv_timer_stop(&ndp->timer);
 
+    if (ndp->ra_inflight)
+        enftun_crb_cancel(&ndp->ra_crb);
+
     return 0;
 }
 


### PR DESCRIPTION
It was observed that enftun would hang when stopping the libuv
event loop, if the tun device link state was down when enftun started.
This hang prevented the automatic reconnect when the connection to the ENF
was lost.

The was due to the NDP code failing to cancel the CRB used to write
the router advertisment (RA) to the tun device. When the tun device is
up, the RA is written immediately.  There is no outstanding CRB when
stopping and thus no hang. When the tun device is down, the CRB is
queued.  Whening stopping, there is still an outstanding CRB and the
event loop does not exit.

The fix is to explicitly cancel the RA CRB when stopping, if one is
outstanding.

The chain code is the only other place that CRBs are submitted. Those
already properly canceled outstanding CRBs when stopping.

Fixes #74 