### PR TITLE
Use router lifetime to advertise default route

### DIFF
--- a/src/icmp.c
+++ b/src/icmp.c
@@ -103,8 +103,7 @@ enftun_icmp6_nd_ra(struct enftun_packet* pkt,
                    const struct in6_addr* src,
                    const struct in6_addr* dst,
                    const struct in6_addr* network, uint16_t prefix,
-                   const char** other_routes,
-                   int lifetime)
+                   const char** other_routes)
 {
     enftun_ip6_reserve(pkt);
 
@@ -125,7 +124,7 @@ enftun_icmp6_nd_ra(struct enftun_packet* pkt,
     if (!mh)
         goto err;
 
-    if (NULL == enftun_icmp6_nd_route_info(pkt, network, prefix, lifetime))
+    if (NULL == enftun_icmp6_nd_route_info(pkt, network, prefix, 0xffffffff))
         goto err;
 
     const char* route;
@@ -149,7 +148,7 @@ enftun_icmp6_nd_ra(struct enftun_packet* pkt,
         default:
             if (NULL == enftun_icmp6_nd_route_info(pkt,
                                                    &prefix, prefixlen,
-                                                   lifetime))
+                                                   0xffffffff))
             {
                 enftun_log_warn("ndp: router advertisment full, "
                                 "skipping route\n");

--- a/src/icmp.h
+++ b/src/icmp.h
@@ -57,8 +57,7 @@ enftun_icmp6_nd_ra(struct enftun_packet* pkt,
                    const struct in6_addr* src,
                    const struct in6_addr* dst,
                    const struct in6_addr* network, uint16_t prefix,
-                   const char** other_routes,
-                   int lifetime);
+                   const char** other_routes);
 
 struct nd_router_solicit*
 enftun_icmp6_nd_rs_pull(struct enftun_packet* pkt, struct ip6_hdr* iph);

--- a/src/ndp.c
+++ b/src/ndp.c
@@ -59,7 +59,7 @@ send_ra(struct enftun_ndp* ndp)
 
     enftun_packet_reset(&ndp->ra_pkt);
     enftun_icmp6_nd_ra(&ndp->ra_pkt, &ip6_self, &ip6_all_nodes,
-                       &ndp->network, 64, ndp->routes, 3 * ndp->ra_period);
+                       &ndp->network, 64, ndp->routes);
 
     enftun_crb_write(&ndp->ra_crb, ndp->chan);
 


### PR DESCRIPTION
Currently enftun advertises routes using route information options in the main RA. Support for these options can be disabled at compile time in the Linux kernel. This is true for some IoT gateways like the Eurotech RG-20-25.

The original RA specification did include support for advertising the default route via the default lifetime parameter. We currently set this to 0 to disable, and advertised the default route (if configured) via the aforementioned option.

To support both current and legacy systems, we should change how the default route is advertised.

Also, fix an issue with the route info lifetimes being specified in milliseconds instead of seconds. Change those lifetimes to infinite, which is best for our use case.

Fixes #76 