### PR TITLE
Support tcp and tcp proxy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ project(enftun
 
 option(BUILD_CACERT  "Install the the ENF ca cert" ON)
 option(BUILD_EXAMPLE "Build and install example configs" ON)
+option(BUILD_PSOCK   "Build with psock support" OFF)
 option(BUILD_SYSTEMD "Build with systemd support" ON)
 option(BUILD_TEST    "Build tests" ON)
 option(BUILD_XTT     "Build with XTT support" ON)
@@ -25,6 +26,10 @@ if(BUILD_XTT)
     add_definitions(-DUSE_XTT)
     find_package(sodium REQUIRED QUIET 1.0.11)
     find_package(xtt COMPONENTS tpm REQUIRED QUIET 0.10.4)
+endif()
+
+if(BUILD_PSOCK)
+    add_definitions(-DUSE_PSOCK)
 endif()
 
 add_compile_options(-std=c99 -Wall -Wextra -Wno-missing-field-initializers)
@@ -65,6 +70,10 @@ set(ENFTUN_SRCS
 
 if(BUILD_XTT)
     list(APPEND ENFTUN_SRCS src/xtt.c)
+endif()
+
+if(BUILD_PSOCK)
+    list(APPEND ENFTUN_SRCS src/tcp_psock.c)
 endif()
 
 add_executable(enftun ${ENFTUN_SRCS})

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The following CMake configuration options are supported.
 | BUILD_SYSTEMD        | ON, OFF        | ON         | Build with systemd support                             |
 | BUILD_TEST           | ON, OFF        | ON         | Build tests                                            |
 | BUILD_XTT            | ON, OFF        | ON         | Build with XTT support                                 |
+| BUILD_PSOCK          | ON, OFF        | OFF        | Build with PSOCK support                               |
+
 
 ## Usage
 

--- a/src/enftun.c
+++ b/src/enftun.c
@@ -39,7 +39,9 @@ trigger_reconnect(struct enftun_conn_state* conn_state);
 static void
 start_all(struct enftun_context* ctx)
 {
+#ifndef USE_PSOCK
     enftun_conn_state_start(&ctx->conn_state, &ctx->tls);
+#endif
     enftun_chain_start(&ctx->ingress, chain_complete);
     enftun_chain_start(&ctx->egress, chain_complete);
     enftun_ndp_start(&ctx->ndp);
@@ -53,7 +55,9 @@ stop_all(struct enftun_context* ctx)
     enftun_ndp_stop(&ctx->ndp);
     enftun_chain_stop(&ctx->ingress);
     enftun_chain_stop(&ctx->egress);
+#ifndef USE_PSOCK
     enftun_conn_state_stop(&ctx->conn_state);
+#endif
 
     enftun_log_info("Stopped.\n");
 }
@@ -225,10 +229,12 @@ enftun_connect(struct enftun_context* ctx)
             goto out;
     }
 
+#ifndef USE_PSOCK
     if ((rc = enftun_conn_state_prepare(&ctx->conn_state, &ctx->loop,
                                         trigger_reconnect, (void*) ctx,
                                         ctx->config.fwmark)) < 0)
         goto out;
+#endif
 
     if ((rc = enftun_tls_connect(&ctx->tls, ctx->config.remote_hosts,
                                  ctx->config.remote_port)) < 0)
@@ -252,7 +258,9 @@ close_tls:
     enftun_tls_disconnect(&ctx->tls);
 
 close_conn_state:
+#ifndef USE_PSOCK
     enftun_conn_state_close(&ctx->conn_state);
+#endif
 
 out:
     return rc;

--- a/src/tcp_psock.c
+++ b/src/tcp_psock.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2018 Xaptum, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <errno.h>
+#include <netdb.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "log.h"
+#include "tcp.h"
+#include "tcp_psock.h"
+
+#define get_sin_addr(addr) (&((struct sockaddr_in*) addr->ai_addr)->sin_addr)
+
+#define get_sin_port(addr) (((struct sockaddr_in*) addr->ai_addr)->sin_port)
+
+static struct enftun_tcp_ops enftun_tcp_psock_ops = {
+    .connect = (int (*)(void*, const char* host, const char*))
+        enftun_tcp_psock_connect,
+    .connect_any =
+        (int (*)(void*, const char** host, const char*)) enftun_tcp_connect_any,
+    .close = (void (*)(void*)) enftun_tcp_close};
+
+void
+enftun_tcp_psock_init(struct enftun_tcp_psock* psock)
+{
+    psock->base.ops = enftun_tcp_psock_ops;
+}
+
+static int
+do_connect(struct enftun_tcp* tcp, struct addrinfo* addr)
+{
+    char ip[45];
+    int port;
+    int rc;
+
+    inet_ntop(addr->ai_family, get_sin_addr(addr), ip, sizeof(ip));
+    port = ntohs(get_sin_port(addr));
+
+    enftun_log_debug("PSOCK: connecting to [%s]:%d\n", ip, port);
+
+    if ((tcp->fd = socket(AF_PSOCK, SOCK_STREAM, addr->ai_protocol)) < 0)
+    {
+        enftun_log_error("PSOCK: Failed to create socket: %s\n",
+                         strerror(errno));
+        rc = -errno;
+        goto out;
+    }
+
+    if ((rc = connect(tcp->fd, addr->ai_addr, addr->ai_addrlen)) < 0)
+    {
+        enftun_log_error("PSOCK: Failed to connect to [%s]:%d: %s\n", ip, port,
+                         strerror(errno));
+        rc = -errno;
+        goto close_fd;
+    }
+
+    enftun_log_info("PSOCK: Connected to [%s]:%d\n", ip, port);
+    goto out;
+
+close_fd:
+    close(tcp->fd);
+    tcp->fd = 0;
+
+out:
+    return rc;
+}
+
+int
+enftun_tcp_psock_connect(struct enftun_tcp* psock,
+                         const char* host,
+                         const char* port)
+{
+    int rc;
+    struct addrinfo *addr_h, *addr, hints;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family   = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_protocol = IPPROTO_TCP;
+    hints.ai_flags    = AI_PASSIVE;
+
+    rc = getaddrinfo(host, port, &hints, &addr_h);
+    if (rc < 0)
+    {
+        enftun_log_error("PSOCK: Cannot resolve %s:%s: %s\n", host, port,
+                         gai_strerror(rc));
+        rc = -1;
+        goto out;
+    }
+
+    for (addr = addr_h; addr != NULL; addr = addr->ai_next)
+    {
+        rc = do_connect(psock, addr);
+        if (rc == 0)
+            break;
+    }
+
+    /* Support is needed to monitor the connection state,
+        but not yet ready
+    if (addr != NULL)
+    {
+        socklen_t length = MAX_SOCKADDR_LEN;
+        getsockname(tcp->fd, &tcp->local_addr, &length);
+        getpeername(tcp->fd, &tcp->remote_addr, &length);
+    }
+    */
+
+    freeaddrinfo(addr_h);
+
+out:
+    return rc;
+}

--- a/src/tcp_psock.h
+++ b/src/tcp_psock.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Xaptum, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef ENFTUN_PSOCK_H
+#define ENFTUN_PSOCK_H
+
+#include "tcp.h"
+
+struct enftun_tcp_psock
+{
+    struct enftun_tcp base;
+};
+
+void
+enftun_tcp_psock_init(struct enftun_tcp_psock* psock);
+
+int
+enftun_tcp_psock_connect(struct enftun_tcp* psock,
+                         const char* host,
+                         const char* port);
+
+#endif

--- a/src/tls.c
+++ b/src/tls.c
@@ -44,8 +44,14 @@ enftun_tls_init(struct enftun_tls* tls, int mark)
         goto out;
     }
 
+#ifdef USE_PSOCK
+    (void) mark;
+    enftun_tcp_psock_init(&tls->sock_psock);
+    tls->sock = &tls->sock_psock.base;
+#else
     enftun_tcp_native_init(&tls->sock_native, mark);
     tls->sock = &tls->sock_native.base;
+#endif
 
     tls->need_provision = 0;
 

--- a/src/tls.h
+++ b/src/tls.h
@@ -28,10 +28,19 @@
 #include "packet.h"
 #include "tcp.h"
 
+#ifdef USE_PSOCK
+#include "tcp_psock.h"
+#endif
+
 struct enftun_tls
 {
     struct enftun_tcp* sock; // the underlying TCP socket
+
+#ifdef USE_PSOCK
+    struct enftun_tcp_psock sock_psock;
+#else
     struct enftun_tcp_native sock_native;
+#endif
 
     int mark; // mark to apply to tunnel packets. 0 to disable
 

--- a/src/xtt.c
+++ b/src/xtt.c
@@ -106,10 +106,19 @@ enftun_xtt_handshake(const char** server_hosts,
                      const char* basename_in,
                      struct enftun_xtt* xtt)
 {
-    struct enftun_tcp_native sock_native;
     struct enftun_tcp* sock;
-    sock = &sock_native.base;
+
+#ifdef USE_PSOCK
+    (void) mark;
+    struct enftun_tcp_psock sock_psock = {0};
+    enftun_tcp_psock_init(&sock_psock);
+    sock = &sock_psock.base;
+#else
+    struct enftun_tcp_native sock_native = {0};
     enftun_tcp_native_init(&sock_native, mark);
+    sock = &sock_native.base;
+#endif
+
     int init_daa_ret = -1;
     int ret          = 0;
 


### PR DESCRIPTION
Add an option for `enftun` to build with support for psock, or tcp via proxy. 

Using the cmake option `-DBUILD_PSOCK` a user can decide whether to use the psock implementation or the normal tcp enftun.

An attempt at supporting both simultaneously was made, but because `conn_state` is not supported by psock, it is proving more difficult.

Connected to Issue #73. 