### PR TITLE
dchp6: use finite address lifetimes

### DIFF
--- a/src/dhcp_msgs.c
+++ b/src/dhcp_msgs.c
@@ -19,6 +19,8 @@
 #include <stdbool.h>
 #include <string.h>
 
+#define DHCP6_ONE_YEAR 31536000
+
 static void*
 dhcp6_find_option(struct enftun_packet* pkt, uint16_t code, uint16_t* len)
 {
@@ -126,13 +128,15 @@ enftun_dhcp6_advertise(struct enftun_packet* pkt,
 
     if (ctx->iaid && caddr)
     {
-        struct dhcp6_option* ia_na =
-            enftun_dhcp6_ia_na_start(pkt, ctx->iaid, 0xFFFFFFF, 0xFFFFFFF);
+        // Set T1 and T2 to .5 and .8 times preferred lifetime, per RFC 3315
+        // Section 22.4
+        struct dhcp6_option* ia_na = enftun_dhcp6_ia_na_start(
+            pkt, ctx->iaid, 0.5 * DHCP6_ONE_YEAR, 0.8 * DHCP6_ONE_YEAR);
         if (!ia_na)
             return NULL;
 
-        struct dhcp6_option* iaaddr =
-            enftun_dhcp6_iaaddr_start(pkt, caddr, 0xFFFFFFFF, 0xFFFFFFFF);
+        struct dhcp6_option* iaaddr = enftun_dhcp6_iaaddr_start(
+            pkt, caddr, DHCP6_ONE_YEAR, DHCP6_ONE_YEAR);
         if (!iaaddr)
             return NULL;
 
@@ -157,13 +161,15 @@ enftun_dhcp6_reply(struct enftun_packet* pkt,
     if (!enftun_dhcp6_serverid(pkt, ctx->sid, ctx->sidlen))
         return NULL;
 
-    struct dhcp6_option* ia_na =
-        enftun_dhcp6_ia_na_start(pkt, ctx->iaid, 0xFFFFFFF, 0xFFFFFFF);
+    // Set T1 and T2 to .5 and .8 times preferred lifetime, per RFC 3315
+    // Section 22.4
+    struct dhcp6_option* ia_na = enftun_dhcp6_ia_na_start(
+        pkt, ctx->iaid, 0.5 * DHCP6_ONE_YEAR, 0.8 * DHCP6_ONE_YEAR);
     if (!ia_na)
         return NULL;
 
     struct dhcp6_option* iaaddr =
-        enftun_dhcp6_iaaddr_start(pkt, caddr, 0xFFFFFFFF, 0xFFFFFFFF);
+        enftun_dhcp6_iaaddr_start(pkt, caddr, DHCP6_ONE_YEAR, DHCP6_ONE_YEAR);
     if (!iaaddr)
         return NULL;
     enftun_dhcp6_iaaddr_finish(pkt, iaaddr);


### PR DESCRIPTION
Some older DHCPv6 clients, specifically connman v1.32 and older, so
not properly support the "infinite" lifetime value 0xFFFFFFFF.

Older version of connman have a second bug. They improperly interpret
the lifetime as a signed integer, so 0xFFFFFFFF becomes -1.  Addresses
are considered expired before they were even assigned.

To workaround this, we specify a finite lifetime.  Because connman
does not properly handle signed vs unsigned ints and the associated
overflow issues, we can't use a large lifetime like 0x7FFFFFFF.  The
lifetime is added to the current time (seconds since the Unix epoch),
which overflows.  So use a relatively short time, 1 year, that won't
overflow.