### PR TITLE
Refactor TCP structs

### DIFF
--- a/src/conn_state.c
+++ b/src/conn_state.c
@@ -33,15 +33,16 @@
 static int
 check_preferred_route(struct enftun_conn_state* conn_state)
 {
-    int rc = enftun_udp_connect_addr(&conn_state->udp, conn_state->mark,
-                                     &conn_state->conn->sock.remote_addr);
+    int rc =
+        enftun_udp_connect_addr(&conn_state->udp, conn_state->mark,
+                                &conn_state->conn->tcp_ctx.socket.remote_addr);
     if (0 != rc)
         return rc;
 
     enftun_udp_close(&conn_state->udp);
 
     rc = enftun_sockaddr_equal(&conn_state->udp.local_addr,
-                               &conn_state->conn->sock.local_addr);
+                               &conn_state->conn->tcp_ctx.socket.local_addr);
 
     return rc;
 }

--- a/src/conn_state.c
+++ b/src/conn_state.c
@@ -33,16 +33,15 @@
 static int
 check_preferred_route(struct enftun_conn_state* conn_state)
 {
-    int rc =
-        enftun_udp_connect_addr(&conn_state->udp, conn_state->mark,
-                                &conn_state->conn->tcp_ctx.base.remote_addr);
+    int rc = enftun_udp_connect_addr(&conn_state->udp, conn_state->mark,
+                                     &conn_state->conn->sock->remote_addr);
     if (0 != rc)
         return rc;
 
     enftun_udp_close(&conn_state->udp);
 
     rc = enftun_sockaddr_equal(&conn_state->udp.local_addr,
-                               &conn_state->conn->tcp_ctx.base.local_addr);
+                               &conn_state->conn->sock->local_addr);
 
     return rc;
 }

--- a/src/conn_state.c
+++ b/src/conn_state.c
@@ -35,14 +35,14 @@ check_preferred_route(struct enftun_conn_state* conn_state)
 {
     int rc =
         enftun_udp_connect_addr(&conn_state->udp, conn_state->mark,
-                                &conn_state->conn->tcp_ctx.socket.remote_addr);
+                                &conn_state->conn->tcp_ctx.base.remote_addr);
     if (0 != rc)
         return rc;
 
     enftun_udp_close(&conn_state->udp);
 
     rc = enftun_sockaddr_equal(&conn_state->udp.local_addr,
-                               &conn_state->conn->tcp_ctx.socket.local_addr);
+                               &conn_state->conn->tcp_ctx.base.local_addr);
 
     return rc;
 }

--- a/src/context.c
+++ b/src/context.c
@@ -61,7 +61,7 @@ enftun_context_init(struct enftun_context* ctx)
     if (rc < 0)
         goto free_config;
 
-    rc = enftun_tls_init(&ctx->tls);
+    rc = enftun_tls_init(&ctx->tls, ctx->config.fwmark);
     if (rc < 0)
         goto free_conn_state;
 

--- a/src/enftun.c
+++ b/src/enftun.c
@@ -124,7 +124,7 @@ enftun_tunnel(struct enftun_context* ctx)
     int rc;
 
     rc = enftun_channel_init(&ctx->tlschan, &enftun_tls_ops, &ctx->tls,
-                             &ctx->loop, ctx->tls.sock.fd);
+                             &ctx->loop, ctx->tls.tcp_ctx.socket.fd);
     if (rc < 0)
         goto out;
 
@@ -230,8 +230,7 @@ enftun_connect(struct enftun_context* ctx)
                                         ctx->config.fwmark)) < 0)
         goto out;
 
-    if ((rc = enftun_tls_connect(&ctx->tls, ctx->config.fwmark,
-                                 ctx->config.remote_hosts,
+    if ((rc = enftun_tls_connect(&ctx->tls, ctx->config.remote_hosts,
                                  ctx->config.remote_port)) < 0)
         goto close_conn_state;
 

--- a/src/enftun.c
+++ b/src/enftun.c
@@ -124,7 +124,7 @@ enftun_tunnel(struct enftun_context* ctx)
     int rc;
 
     rc = enftun_channel_init(&ctx->tlschan, &enftun_tls_ops, &ctx->tls,
-                             &ctx->loop, ctx->tls.tcp_ctx.socket.fd);
+                             &ctx->loop, ctx->tls.tcp_ctx.base.fd);
     if (rc < 0)
         goto out;
 

--- a/src/enftun.c
+++ b/src/enftun.c
@@ -124,7 +124,7 @@ enftun_tunnel(struct enftun_context* ctx)
     int rc;
 
     rc = enftun_channel_init(&ctx->tlschan, &enftun_tls_ops, &ctx->tls,
-                             &ctx->loop, ctx->tls.tcp_ctx.base.fd);
+                             &ctx->loop, ctx->tls.sock->fd);
     if (rc < 0)
         goto out;
 

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -53,9 +53,7 @@ struct enftun_tcp_native
 };
 
 void
-enftun_tcp_native_init(struct enftun_tcp_native* ctx,
-                       struct enftun_tcp* sock,
-                       int mark);
+enftun_tcp_native_init(struct enftun_tcp_native* ctx, int mark);
 
 int
 enftun_tcp_native_connect(struct enftun_tcp_native* tcp,
@@ -63,11 +61,11 @@ enftun_tcp_native_connect(struct enftun_tcp_native* tcp,
                           const char* port);
 
 int
-enftun_tcp_native_connect_any(struct enftun_tcp_native* tcp,
-                              const char** hosts,
-                              const char* port);
+enftun_tcp_connect_any(struct enftun_tcp* tcp,
+                       const char** hosts,
+                       const char* port);
 
 void
-enftun_tcp_native_close(struct enftun_tcp_native* tcp);
+enftun_tcp_close(struct enftun_tcp* tcp);
 
 #endif

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -48,7 +48,7 @@ struct enftun_tcp
 
 struct enftun_tcp_native
 {
-    struct enftun_tcp socket;
+    struct enftun_tcp base;
     int fwmark;
 };
 

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -23,6 +23,13 @@
 
 #define MAX_SOCKADDR_LEN sizeof(struct sockaddr_in6)
 
+struct enftun_tcp_ops
+{
+    int (*connect)(void* ctx, const char* host, const char* port);
+    int (*connect_any)(void* ctx, const char** host, const char* port);
+    void (*close)(void* ctx);
+};
+
 struct enftun_tcp
 {
     int fd; // file descriptor for the underlying TCP socket
@@ -35,21 +42,32 @@ struct enftun_tcp
         struct sockaddr remote_addr;
         char _remote_addr_pad[MAX_SOCKADDR_LEN];
     };
+
+    struct enftun_tcp_ops ops;
 };
 
-int
-enftun_tcp_connect(struct enftun_tcp* tcp,
-                   int mark,
-                   const char* host,
-                   const char* port);
-
-int
-enftun_tcp_connect_any(struct enftun_tcp* tcp,
-                       int mark,
-                       const char** hosts,
-                       const char* port);
+struct enftun_tcp_native
+{
+    struct enftun_tcp socket;
+    int fwmark;
+};
 
 void
-enftun_tcp_close(struct enftun_tcp* tcp);
+enftun_tcp_native_init(struct enftun_tcp_native* ctx,
+                       struct enftun_tcp* sock,
+                       int mark);
+
+int
+enftun_tcp_native_connect(struct enftun_tcp_native* tcp,
+                          const char* host,
+                          const char* port);
+
+int
+enftun_tcp_native_connect_any(struct enftun_tcp_native* tcp,
+                              const char** hosts,
+                              const char* port);
+
+void
+enftun_tcp_native_close(struct enftun_tcp_native* tcp);
 
 #endif

--- a/src/tls.c
+++ b/src/tls.c
@@ -32,7 +32,7 @@ struct enftun_channel_ops enftun_tls_ops = {
     .pending = (int (*)(void*)) enftun_tls_pending};
 
 int
-enftun_tls_init(struct enftun_tls* tls)
+enftun_tls_init(struct enftun_tls* tls, int mark)
 {
     int rc = 0;
 
@@ -43,6 +43,8 @@ enftun_tls_init(struct enftun_tls* tls)
         rc = -1;
         goto out;
     }
+
+    enftun_tcp_native_init(&tls->tcp_ctx, &tls->tcp_ctx.socket, mark);
 
     tls->need_provision = 0;
 
@@ -121,10 +123,10 @@ enftun_tls_handshake(struct enftun_tls* tls)
         goto free_ssl;
     }
 
-    if (!SSL_set_fd(tls->ssl, tls->sock.fd))
+    if (!SSL_set_fd(tls->ssl, tls->tcp_ctx.socket.fd))
     {
         enftun_log_ssl_error("Failed to set SSL file descriptor (%d):",
-                             tls->sock.fd);
+                             tls->tcp_ctx.socket.fd);
         goto free_ssl;
     }
 
@@ -167,20 +169,17 @@ out:
 }
 
 int
-enftun_tls_connect(struct enftun_tls* tls,
-                   int mark,
-                   const char** hosts,
-                   const char* port)
+enftun_tls_connect(struct enftun_tls* tls, const char** hosts, const char* port)
 {
     int rc;
 
-    rc = enftun_tcp_connect_any(&tls->sock, mark, hosts, port);
+    rc = tls->tcp_ctx.socket.ops.connect_any(&tls->tcp_ctx, hosts, port);
     if (rc < 0)
         goto out;
 
     rc = enftun_tls_handshake(tls);
     if (rc < 0)
-        enftun_tcp_close(&tls->sock);
+        tls->tcp_ctx.socket.ops.close(&tls->sock);
 
 out:
     return rc;
@@ -208,7 +207,7 @@ enftun_tls_disconnect(struct enftun_tls* tls)
         }
     }
 
-    enftun_tcp_close(&tls->sock);
+    tls->tcp_ctx.socket.ops.close(&tls->sock);
     SSL_free(tls->ssl);
 
     return 0;

--- a/src/tls.h
+++ b/src/tls.h
@@ -30,9 +30,10 @@
 
 struct enftun_tls
 {
-    int mark; // mark to apply to tunnel packets. 0 to disable
+    struct enftun_tcp* sock; // the underlying TCP socket
+    struct enftun_tcp_native tcp_ctx;
 
-    struct enftun_tcp sock; // the underlying TCP socket
+    int mark; // mark to apply to tunnel packets. 0 to disable
 
     SSL_CTX* ctx; // the openSSL context
     SSL* ssl;     // the openSSL connection
@@ -45,7 +46,7 @@ struct enftun_tls
 extern struct enftun_channel_ops enftun_tls_ops;
 
 int
-enftun_tls_init(struct enftun_tls* tls);
+enftun_tls_init(struct enftun_tls* tls, int mark);
 
 int
 enftun_tls_free(struct enftun_tls* tls);
@@ -58,7 +59,6 @@ enftun_tls_load_credentials(struct enftun_tls* tls,
 
 int
 enftun_tls_connect(struct enftun_tls* tls,
-                   int mark,
                    const char** hosts,
                    const char* port);
 

--- a/src/tls.h
+++ b/src/tls.h
@@ -31,7 +31,7 @@
 struct enftun_tls
 {
     struct enftun_tcp* sock; // the underlying TCP socket
-    struct enftun_tcp_native tcp_ctx;
+    struct enftun_tcp_native sock_native;
 
     int mark; // mark to apply to tunnel packets. 0 to disable
 

--- a/src/xtt.c
+++ b/src/xtt.c
@@ -106,8 +106,10 @@ enftun_xtt_handshake(const char** server_hosts,
                      const char* basename_in,
                      struct enftun_xtt* xtt)
 {
-    struct enftun_tcp_native sock;
-    enftun_tcp_native_init(&sock, &sock.base, mark);
+    struct enftun_tcp_native sock_native;
+    struct enftun_tcp* sock;
+    sock = &sock_native.base;
+    enftun_tcp_native_init(&sock_native, mark);
     int init_daa_ret = -1;
     int ret          = 0;
 
@@ -226,7 +228,7 @@ enftun_xtt_handshake(const char** server_hosts,
     }
 
     // 2) Make TCP connection to server.
-    ret = sock.base.ops.connect_any(&sock, server_hosts, (char*) server_port);
+    ret = sock->ops.connect_any(&sock, server_hosts, (char*) server_port);
     if (ret < 0)
     {
         ret = 1;
@@ -251,8 +253,8 @@ enftun_xtt_handshake(const char** server_hosts,
     }
 
     // 4) Run the identity-provisioning handshake with the server.
-    ret = do_handshake_client(sock.base.fd, &requested_client_id, &group_ctx,
-                              &ctx, &saved_root_id, &saved_cert);
+    ret = do_handshake_client(sock->fd, &requested_client_id, &group_ctx, &ctx,
+                              &saved_root_id, &saved_cert);
     if (0 == ret)
     {
         // 6) Save the results (what we and the server now agree on
@@ -269,7 +271,7 @@ enftun_xtt_handshake(const char** server_hosts,
     }
 
 finish:
-    sock.base.ops.close(&sock);
+    sock->ops.close(&sock);
     xtt_free_tpm_context(&xtt->tpm_ctx);
     if (0 == ret)
     {

--- a/src/xtt.c
+++ b/src/xtt.c
@@ -107,7 +107,7 @@ enftun_xtt_handshake(const char** server_hosts,
                      struct enftun_xtt* xtt)
 {
     struct enftun_tcp_native sock;
-    enftun_tcp_native_init(&sock, &sock.socket, mark);
+    enftun_tcp_native_init(&sock, &sock.base, mark);
     int init_daa_ret = -1;
     int ret          = 0;
 
@@ -226,7 +226,7 @@ enftun_xtt_handshake(const char** server_hosts,
     }
 
     // 2) Make TCP connection to server.
-    ret = sock.socket.ops.connect_any(&sock, server_hosts, (char*) server_port);
+    ret = sock.base.ops.connect_any(&sock, server_hosts, (char*) server_port);
     if (ret < 0)
     {
         ret = 1;
@@ -251,7 +251,7 @@ enftun_xtt_handshake(const char** server_hosts,
     }
 
     // 4) Run the identity-provisioning handshake with the server.
-    ret = do_handshake_client(sock.socket.fd, &requested_client_id, &group_ctx,
+    ret = do_handshake_client(sock.base.fd, &requested_client_id, &group_ctx,
                               &ctx, &saved_root_id, &saved_cert);
     if (0 == ret)
     {
@@ -269,7 +269,7 @@ enftun_xtt_handshake(const char** server_hosts,
     }
 
 finish:
-    sock.socket.ops.close(&sock);
+    sock.base.ops.close(&sock);
     xtt_free_tpm_context(&xtt->tpm_ctx);
     if (0 == ret)
     {


### PR DESCRIPTION
Change the way that enftun_tcp is formatted for future additions.

This adds `enftun_tcp_native`  which includes an `enftun_tcp` struct. That struct holds the original file descriptor, local address, and remote address and also a struct (`enftun_tcp_ops`) that holds the 3 necessary functions `connect`, `connect_any`, and `close`.