### PR TITLE
Reserve 2 bytes for stream header in packet reset

### DIFF
--- a/src/channel.c
+++ b/src/channel.c
@@ -142,7 +142,6 @@ void
 enftun_crb_read(struct enftun_crb* crb, struct enftun_channel* chan)
 {
     enftun_packet_reset(crb->packet);
-    enftun_packet_reserve_head(crb->packet, 2); // space for stream header
 
     crb->channel = chan;
 

--- a/src/packet.c
+++ b/src/packet.c
@@ -32,6 +32,8 @@ enftun_packet_reset(struct enftun_packet* pkt)
     pkt->tail = pkt->data;
 
     pkt->size = 0;
+
+    enftun_packet_reserve_head(pkt, 2); // space for stream header
 }
 
 void


### PR DESCRIPTION
Moved to accomodate writing to a TLS tunnel without having to manually add the 2 byte buffer every time.