### PR TITLE
Fix xtt socket handling

### DIFF
--- a/src/tcp.c
+++ b/src/tcp.c
@@ -33,11 +33,10 @@
 #define get_sin_port(addr) (((struct sockaddr_in*) addr->ai_addr)->sin_port)
 
 static struct enftun_tcp_ops enftun_tcp_native_ops = {
-    .connect = (int (*)(void*, const char* host, const char*))
+    .connect = (int (*)(struct enftun_tcp*, const char* host, const char*))
         enftun_tcp_native_connect,
-    .connect_any =
-        (int (*)(void*, const char** host, const char*)) enftun_tcp_connect_any,
-    .close = (void (*)(void*)) enftun_tcp_close};
+    .connect_any = enftun_tcp_connect_any,
+    .close       = enftun_tcp_close};
 
 void
 enftun_tcp_native_init(struct enftun_tcp_native* tcp, int mark)

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -23,11 +23,15 @@
 
 #define MAX_SOCKADDR_LEN sizeof(struct sockaddr_in6)
 
+struct enftun_tcp;
+
 struct enftun_tcp_ops
 {
-    int (*connect)(void* ctx, const char* host, const char* port);
-    int (*connect_any)(void* ctx, const char** host, const char* port);
-    void (*close)(void* ctx);
+    int (*connect)(struct enftun_tcp* sock, const char* host, const char* port);
+    int (*connect_any)(struct enftun_tcp* sock,
+                       const char** host,
+                       const char* port);
+    void (*close)(struct enftun_tcp* sock);
 };
 
 struct enftun_tcp

--- a/src/tcp_psock.c
+++ b/src/tcp_psock.c
@@ -34,11 +34,10 @@
 #define get_sin_port(addr) (((struct sockaddr_in*) addr->ai_addr)->sin_port)
 
 static struct enftun_tcp_ops enftun_tcp_psock_ops = {
-    .connect = (int (*)(void*, const char* host, const char*))
+    .connect = (int (*)(struct enftun_tcp*, const char* host, const char*))
         enftun_tcp_psock_connect,
-    .connect_any =
-        (int (*)(void*, const char** host, const char*)) enftun_tcp_connect_any,
-    .close = (void (*)(void*)) enftun_tcp_close};
+    .connect_any = enftun_tcp_connect_any,
+    .close       = enftun_tcp_close};
 
 void
 enftun_tcp_psock_init(struct enftun_tcp_psock* psock)

--- a/src/xtt.c
+++ b/src/xtt.c
@@ -237,7 +237,7 @@ enftun_xtt_handshake(const char** server_hosts,
     }
 
     // 2) Make TCP connection to server.
-    ret = sock->ops.connect_any(&sock, server_hosts, (char*) server_port);
+    ret = sock->ops.connect_any(sock, server_hosts, (char*) server_port);
     if (ret < 0)
     {
         ret = 1;
@@ -280,7 +280,7 @@ enftun_xtt_handshake(const char** server_hosts,
     }
 
 finish:
-    sock->ops.close(&sock);
+    sock->ops.close(sock);
     xtt_free_tpm_context(&xtt->tpm_ctx);
     if (0 == ret)
     {


### PR DESCRIPTION
The refactoring to add PSOCK support introduced a bug into the XTT provisioning code that manifested as a SEGFAULT.  

Consider a structure and function:
```
struct foo;
do_with_foo(void*);

Code of the form
```
struct foo f;
do_with_foo(&f);
```
was changed to
```
struct foo* f;
do_with_foo(&f);  // f is now already a pointer, so should be changed to do_with_foo(f)
```

Unfortunately, due to the `void*` argument, the type checker did not catch this mistake.

This PR both
1) removes the extra `&` operator
2) change the signature of `do_with_foo(void*)` to `doo_with_foo(struct foo*)` to avoid similar problems in the future.

