### PR TITLE
context: zero out the ipv6 string buffer before reading cert

### DIFF
--- a/src/context.c
+++ b/src/context.c
@@ -117,6 +117,8 @@ enftun_context_ipv6_from_cert(struct enftun_context* ctx, const char* file)
 {
     int rc;
 
+    memset(ctx->ipv6_str, 0, sizeof(ctx->ipv6_str));
+
     if ((rc = enftun_cert_common_name_file(ctx->config.cert_file, ctx->ipv6_str,
                                            sizeof(ctx->ipv6_str))) < 0)
     {


### PR DESCRIPTION
The ipv6 string was not zeroed before re-reading the certificate
file. If the cert changed such that the new ipv6 string was shorter
(for example, if a run of zeros was replaced with a ::), then the ipv6
string buffer would contain the concatentation of the new address and
the remainder of the old address. Obviously, this is invalid and
incorrect.

Prevent this errror by zeroing the ipv6 string buffer before reading
the certificate file.