### PR TITLE
Support openssl 1.0.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(GNUInstallDirs)
 
 find_package(LibConfig REQUIRED QUIET 1.5)
 find_package(LibUV REQUIRED QUIET 1.9)
-find_package(OpenSSL REQUIRED QUIET 1.1)
+find_package(OpenSSL REQUIRED QUIET 1.0)
 
 if(BUILD_XTT)
     add_definitions(-DUSE_TPM)

--- a/cmake/FindLibConfig.cmake
+++ b/cmake/FindLibConfig.cmake
@@ -62,7 +62,6 @@ They may be set by end users to point at libconfig components.
 find_library(LibConfig_LIBRARY
   NAMES config
   )
-message("LibConfig_LIBRARY is ${LibConfig_LIBRARY}")
 mark_as_advanced(LibConfig_LIBRARY)
 
 find_path(LibConfig_INCLUDE_DIR

--- a/cmake/Findsodium.cmake
+++ b/cmake/Findsodium.cmake
@@ -252,6 +252,8 @@ if(sodium_USE_STATIC_LIBS)
 else()
     set(_LIB_TYPE SHARED)
 endif()
+
+if(NOT TARGET sodium)
 add_library(sodium ${_LIB_TYPE} IMPORTED)
 
 set_target_properties(sodium PROPERTIES
@@ -289,4 +291,5 @@ else()
             )
         endif()
     endif()
+endif()
 endif()


### PR DESCRIPTION
 Some IoT gateways and other embedded products have OpenSSL 1.0.x, not the OpenSSL 1.1.x required by enftun.  Upgrading the version of OpenSSL on these platforms is non-trivial, if even possible. So to support them, its easier to adapt enftun to the older version of OpenSSL.
    
Our usage of the new APIs in 1.1.x is limited to convenience methods for restricting the allowed version of TLS to 1.2.  This same behavior can be enforced on older versions with slightly more verbose code.