### PR TITLE
packet: ensure that packet is word aligned

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,4 +100,5 @@ matrix:
         - COMPILER=/usr/bin/clang
     - name: "Check source code format"
       script:
-        - ${TRAVIS_BUILD_DIR}/format.sh check
+        - docker run -v $(pwd):/enftun/ -d -t --name enftun xaptumeng/enftun-build:0.1.1
+        - docker exec -it enftun bash -c "cd enftun && ./format.sh check"

--- a/src/packet.c
+++ b/src/packet.c
@@ -33,7 +33,7 @@ enftun_packet_reset(struct enftun_packet* pkt)
 
     pkt->size = 0;
 
-    enftun_packet_reserve_head(pkt, 2); // space for stream header
+    enftun_packet_reserve_head(pkt, 4); // space for stream header while staying word aligned
 }
 
 void

--- a/src/packet.c
+++ b/src/packet.c
@@ -33,7 +33,8 @@ enftun_packet_reset(struct enftun_packet* pkt)
 
     pkt->size = 0;
 
-    enftun_packet_reserve_head(pkt, 4); // space for stream header while staying word aligned
+    enftun_packet_reserve_head(
+        pkt, 4); // space for stream header while staying word aligned
 }
 
 void

--- a/src/tcp.c
+++ b/src/tcp.c
@@ -193,7 +193,7 @@ enftun_tcp_close(struct enftun_tcp* tcp)
 }
 
 static struct enftun_tcp_ops enftun_tcp_native_ops = {
-    .connect     = (int (*)(struct enftun_tcp* sock,
+    .connect = (int (*)(struct enftun_tcp* sock,
                         const char* host,
                         const char* port,
                         int fwmark)) enftun_tcp_native_connect,

--- a/src/tls.c
+++ b/src/tls.c
@@ -127,8 +127,8 @@ enftun_tls_handshake(struct enftun_tls* tls)
     }
 
 #if OPENSSL_VERSION_NUMBER < 0x10100000
-    SSL_set_options(tls->ssl, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_TLSv1 |
-                    SSL_OP_NO_TLSv1_1);
+    SSL_set_options(tls->ssl, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 |
+                                  SSL_OP_NO_TLSv1 | SSL_OP_NO_TLSv1_1);
 #else
     if (SSL_set_min_proto_version(tls->ssl, TLS1_2_VERSION) != 1)
     {

--- a/src/tls.c
+++ b/src/tls.c
@@ -306,6 +306,16 @@ enftun_tls_read_packet(struct enftun_tls* tls, struct enftun_packet* pkt)
     int rc;
     size_t len;
 
+    /*
+     * If starting to read a new packet, ensure the TLS stream header
+     * is half-word aligned so that the actual packet paylaod will be
+     * word aligned.
+     */
+    if (pkt->size == 0)
+    {
+        enftun_packet_reserve_head(pkt, 2);
+    }
+
     len = size_to_read(pkt);
     if (len > enftun_packet_tailroom(pkt))
     {

--- a/src/xtt.c
+++ b/src/xtt.c
@@ -118,7 +118,7 @@ enftun_xtt_handshake(const char** server_hosts,
     setbuf(stdout, NULL);
 
     xtt_identity_type requested_client_id = {.data = {0}};
-    requested_client_id                   = xtt_null_identity;
+    requested_client_id = xtt_null_identity;
 
     // Set suite spec from command line args
     xtt_suite_spec suite_spec = 0;
@@ -185,13 +185,13 @@ enftun_xtt_handshake(const char** server_hosts,
     // 1) Setup the needed XTT contexts (from files/TPM).
     // 1i) Read in DAA data from the TPm or from files
 
-    xtt_daa_group_pub_key_lrsw gpk        = {.data = {0}};
-    xtt_daa_credential_lrsw cred          = {.data = {0}};
+    xtt_daa_group_pub_key_lrsw gpk = {.data = {0}};
+    xtt_daa_credential_lrsw cred = {.data = {0}};
     xtt_root_certificate root_certificate = {.data = {0}};
-    unsigned char basename[1024]          = {0};
-    uint16_t basename_len                 = sizeof(basename);
-    unsigned char tls_root_cert[1024]     = {0};
-    uint16_t tls_len                      = sizeof(tls_root_cert);
+    unsigned char basename[1024]                   = {0};
+    uint16_t basename_len                          = sizeof(basename);
+    unsigned char tls_root_cert[1024]              = {0};
+    uint16_t tls_len                               = sizeof(tls_root_cert);
 
     ret = read_in_from_TPM(&xtt->tpm_ctx, basename, &basename_len, &gpk, &cred,
                            &root_certificate, tls_root_cert, &tls_len);
@@ -211,7 +211,7 @@ enftun_xtt_handshake(const char** server_hosts,
     struct xtt_client_group_context group_ctx;
     init_daa_ret = initialize_daa(&group_ctx, basename, basename_len, &gpk,
                                   &cred, &xtt->tpm_ctx, basename_in);
-    ret          = init_daa_ret;
+    ret = init_daa_ret;
     if (0 != init_daa_ret)
     {
         enftun_log_error("Error initializing DAA context\n");
@@ -401,8 +401,8 @@ initialize_certs(struct xtt_server_root_certificate_context* saved_cert,
                  xtt_certificate_root_id* saved_root_id,
                  xtt_root_certificate* root_certificate)
 {
-    xtt_return_code_type rc               = 0;
-    xtt_certificate_root_id root_id       = {.data = {0}};
+    xtt_return_code_type rc         = 0;
+    xtt_certificate_root_id root_id = {.data = {0}};
     xtt_ecdsap256_pub_key root_public_key = {.data = {0}};
 
     // Initialize stored data


### PR DESCRIPTION
The various header processing code (ip.c, icmp.c, ndp.c, etc.) require
that the packet be word aligned. Otherwise, it will generate unaligned
memory access traps on some older ARM architectures.

The TLS stream header length is 2 bytes, causing some accesses to be
unaligned.  Fix this by using reserve enough bytes in the header to
ensure that the TLS stream header is half-word aligned and the packet
payload is word aligned.

Fixes #114 