### PR TITLE
Fix allocation error with default enftun_path

### DIFF
--- a/keygen/src/main.c
+++ b/keygen/src/main.c
@@ -111,7 +111,7 @@ static int parse_args(int argc, char **argv, char **ipv6_network, char **enftun_
 
     /* Use the default enftun path if none is set */
     if (!*enftun_path) {
-        *enftun_path = malloc(sizeof(enftun_def_path));
+        *enftun_path = malloc(strlen(enftun_def_path) + 1);
         strcpy(*enftun_path, enftun_def_path);
     }
 


### PR DESCRIPTION
Fixes #118 
This error presents in Valgrind as the following

```
==2089== Invalid write of size 1
==2089==    at 0x4C2EE98: strcpy (vg_replace_strmem.c:506)
==2089==    by 0x10ADD0: parse_args (in /home/dev/code/enftun/keygen/enftun-keygen)
==2089==    by 0x10B27D: main (in /home/dev/code/enftun/keygen/enftun-keygen)
==2089==  Address 0xab2de58 is 0 bytes after a block of size 8 alloc'd
==2089==    at 0x4C2BBAF: malloc (vg_replace_malloc.c:299)
==2089==    by 0x10ADB0: parse_args (in /home/dev/code/enftun/keygen/enftun-keygen)
==2089==    by 0x10B27D: main (in /home/dev/code/enftun/keygen/enftun-keygen)
==2089== 
==2089== Invalid write of size 1
==2089==    at 0x4C2EEA7: strcpy (vg_replace_strmem.c:506)
==2089==    by 0x10ADD0: parse_args (in /home/dev/code/enftun/keygen/enftun-keygen)
==2089==    by 0x10B27D: main (in /home/dev/code/enftun/keygen/enftun-keygen)
==2089==  Address 0xab2de5c is 4 bytes after a block of size 8 alloc'd
==2089==    at 0x4C2BBAF: malloc (vg_replace_malloc.c:299)
==2089==    by 0x10ADB0: parse_args (in /home/dev/code/enftun/keygen/enftun-keygen)
==2089==    by 0x10B27D: main (in /home/dev/code/enftun/keygen/enftun-keygen)
==2089== 
```

No errors happen once this commit is applied. 