### PR TITLE
Rename SCM to HSS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(enftun
 
 option(BUILD_CACERT  "Install the the ENF ca cert" ON)
 option(BUILD_EXAMPLE "Build and install example configs" ON)
-option(BUILD_SCM   "Build with scm support" OFF)
+option(BUILD_HSS   "Build with hss support" OFF)
 option(BUILD_SYSTEMD "Build with systemd support" ON)
 option(BUILD_TEST    "Build tests" ON)
 option(BUILD_XTT     "Build with XTT support" ON)
@@ -30,8 +30,8 @@ if(BUILD_XTT)
     find_package(xtt COMPONENTS tpm REQUIRED QUIET 0.10.4)
 endif()
 
-if(BUILD_SCM)
-    add_definitions(-DUSE_SCM)
+if(BUILD_HSS)
+    add_definitions(-DUSE_HSS)
 endif()
 
 add_compile_options(-std=c99 -Wall -Wextra -Wno-missing-field-initializers -Wno-missing-braces)
@@ -75,8 +75,8 @@ if(BUILD_XTT)
     list(APPEND ENFTUN_SRCS src/xtt.c)
 endif()
 
-if(BUILD_SCM)
-    list(APPEND ENFTUN_SRCS src/tcp_scm.c)
+if(BUILD_HSS)
+    list(APPEND ENFTUN_SRCS src/tcp_hss.c)
 endif()
 
 add_executable(enftun ${ENFTUN_SRCS})

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following CMake configuration options are supported.
 | BUILD_SYSTEMD        | ON, OFF        | ON         | Build with systemd support                             |
 | BUILD_TEST           | ON, OFF        | ON         | Build tests                                            |
 | BUILD_XTT            | ON, OFF        | ON         | Build with XTT support                                 |
-| BUILD_SCM            | ON, OFF        | OFF        | Build with SCM support                                 |
+| BUILD_HSS            | ON, OFF        | OFF        | Build with HSS support                                 |
 
 
 ## Usage

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -27,7 +27,7 @@
 enum enftun_tcp_type
 {
     ENFTUN_TCP_NATIVE,
-    ENFTUN_TCP_SCM,
+    ENFTUN_TCP_HSS,
     ENFTUN_TCP_NONE,
     ENFTUN_TCP_MAX
 };

--- a/src/tcp_hss.h
+++ b/src/tcp_hss.h
@@ -16,14 +16,14 @@
 
 #pragma once
 
-#ifndef ENFTUN_SCM_H
-#define ENFTUN_SCM_H
+#ifndef ENFTUN_HSS_H
+#define ENFTUN_HSS_H
 
 #include "tcp.h"
 
-// TCP SCM specific functions
+// TCP HSS specific functions
 
 void
-enftun_tcp_scm_init(struct enftun_tcp* scm);
+enftun_tcp_hss_init(struct enftun_tcp* hss);
 
 #endif

--- a/src/tcp_multi.c
+++ b/src/tcp_multi.c
@@ -29,8 +29,8 @@
 #include "log.h"
 #include "tcp.h"
 #include "tcp_multi.h"
-#ifdef USE_SCM
-#include "tcp_scm.h"
+#ifdef USE_HSS
+#include "tcp_hss.h"
 #endif
 
 static int
@@ -47,8 +47,8 @@ enftun_tcp_multi_connect_any(struct enftun_tcp* tcp,
 typedef void (*enftun_multi_init_type)(struct enftun_tcp* tcp);
 static enftun_multi_init_type enftun_multi_init_types[] = {
     enftun_tcp_native_init,
-#ifdef USE_SCM
-    enftun_tcp_scm_init,
+#ifdef USE_HSS
+    enftun_tcp_hss_init,
 #endif
 };
 static const int enftun_tcp_ops_size =

--- a/src/tcp_multi.h
+++ b/src/tcp_multi.h
@@ -24,6 +24,6 @@
 // TCP Multi specific functions
 
 void
-enftun_tcp_multi_init(struct enftun_tcp* scm);
+enftun_tcp_multi_init(struct enftun_tcp* hss);
 
 #endif


### PR DESCRIPTION
Let me manually confirm this again on the board tonight before merging, but this should be all the changed required for the HSS rename, then the buildroot changes should be easy to apply. 