### PR TITLE
tpm: Fix tpm_password strlen call.

### DIFF
--- a/keygen/src/main.c
+++ b/keygen/src/main.c
@@ -291,7 +291,7 @@ int main(int argc, char **argv)
                 cfg.tpm_parent,
                 cfg.tpm_hierarchy,
                 cfg.tpm_password,
-                strlen(cfg.tpm_password));
+                cfg.tpm_password ? strlen(cfg.tpm_password) : 0);
         if (!ret) {
             printf("Failed. Exiting.\n");
             goto cleanup;

--- a/src/xtt.c
+++ b/src/xtt.c
@@ -250,7 +250,8 @@ enftun_xtt_handshake(const char** server_hosts,
     xtt_return_code_type rc = xtt_initialize_client_handshake_context_TPM(
         &ctx, in_buffer, sizeof(in_buffer), out_buffer, sizeof(out_buffer),
         XTT_VERSION_ONE, suite_spec, tpm_hierarchy, tpm_password,
-        strlen(tpm_password), tpm_parent, xtt->tpm_ctx.tcti_context);
+        tpm_password ? strlen(tpm_password) : 0, tpm_parent,
+        xtt->tpm_ctx.tcti_context);
     if (XTT_RETURN_SUCCESS != rc)
     {
         ret = 1;


### PR DESCRIPTION
This PR fixes an oversight made in the recent PR adding TPM support for the XTT longterm key and keygen utility.

If `tpm_password` is `NULL`, the unconditional calls to `strlen` will segfault. This fixes that by only using `strlen` if `tpm_password` is non-`NULL`.