### PR TITLE
Add CLI option to display version number

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,13 @@ if(BUILD_HSS)
     list(APPEND ENFTUN_SRCS src/tcp_hss.c)
 endif()
 
+configure_file(src/version.h.in version.h)
+
 add_executable(enftun ${ENFTUN_SRCS})
+
+target_include_directories(enftun PRIVATE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+)
 
 target_link_libraries(enftun
   PRIVATE

--- a/src/options.c
+++ b/src/options.c
@@ -23,11 +23,18 @@
 #include "log.h"
 #include "memory.h"
 #include "options.h"
+#include "version.h"
 
 static void
 print_usage()
 {
-    puts("usage: enftun [-h] -c conf_file [-p key]");
+    puts("usage: enftun [-h] [-v] -c conf_file [-p key]");
+}
+
+static void
+print_version()
+{
+    puts("" ENFTUN_VERSION);
 }
 
 int
@@ -55,12 +62,15 @@ enftun_options_parse_argv(struct enftun_options* opts,
                           char* argv[])
 {
     int c;
-    while ((c = getopt(argc, argv, "hc:p:")) != -1)
+    while ((c = getopt(argc, argv, "hvc:p:")) != -1)
     {
         switch (c)
         {
         case 'h':
             print_usage();
+            return -EINVAL;
+        case 'v':
+            print_version();
             return -EINVAL;
         case 'c':
             opts->conf_file = optarg;

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 Xaptum, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef ENFTUN_VERSION_H
+#define ENFTUN_VERSION_H
+
+#define ENFTUN_VERSION       "@PROJECT_VERSION@"
+#define ENFTUN_VERSION_MAJOR "@PROJECT_VERSION_MAJOR@"
+#define ENFTUN_VERSION_MINOR "@PROJECT_VERSION_MINOR@"
+#define ENFTUN_VERSION_PATCH "@PROJECT_VERSION_PATCH@"
+
+#endif // ENFTUN_VERSION_H


### PR DESCRIPTION
Fixes #130 

This PR adds a `-v` option to `enftun` that displays the version number.  ` CMakeLists.txt` is already the source of truth for the version number.  To get this into the C code, a new `version.h.in` header template is introduced.

This request came from a Lanner engineer writing the SOP for integrating `enftun` into their hardware. Apparently their SOPs require a way to confirm the installed version.

I did not update `enftun-keygen` to display a version number.  That should be done eventually, but will require some broader refactoring first:
- share the version number from the main project (keygen is currently stuck at 0.0.1)
- rework the argv parsing to support "command" options like version and help.

clang-format was complaining about some other files, so the second commit fixes those. I'm not sure how they snuck through before...