### PR TITLE
Allow IPv4 traffic through tunnel

### DIFF
--- a/example/device.conf
+++ b/example/device.conf
@@ -70,6 +70,9 @@ route : {
   #
   # This option is only used by the enftun-setup script.
   # trusted_interfaces = [ ]
+
+  # If set to true, IPv4 packets will be allowed through the tunnel.
+  # allow_ipv4 = false
 }
 
 # Identity settings

--- a/example/server.conf
+++ b/example/server.conf
@@ -59,6 +59,9 @@ route : {
   # for these interfaces will be allowed to bypass the tunnel.
   #
   # trusted_interfaces = [ ]
+
+  # If set to true, IPv4 packets will be allowed through the tunnel.
+  # allow_ipv4 = false
 }
 
 # Identity settings

--- a/src/config.c
+++ b/src/config.c
@@ -96,6 +96,8 @@ enftun_config_init(struct enftun_config* config)
 
     config->trusted_ifaces = calloc(2, sizeof(char*));
 
+    config->allow_ipv4 = 0; // false
+
     config->ra_period         = 10 * 60 * 1000; // milliseconds
     config->heartbeat_period  = 5 * 60 * 1000;
     config->heartbeat_timeout = 15 * 1000;
@@ -176,6 +178,7 @@ enftun_config_parse(struct enftun_config* config, const char* file)
     lookup_string_array(cfg, "route.prefixes", &config->prefixes);
     lookup_string_array(cfg, "route.trusted_interfaces",
                         &config->trusted_ifaces);
+    config_lookup_bool(cfg, "route.allow_ipv4", &config->allow_ipv4);
     config_lookup_int(cfg, "route.ra_period", &config->ra_period);
     config_lookup_int(cfg, "route.heartbeat_period", &config->heartbeat_period);
     config_lookup_int(cfg, "route.heartbeat_timeout",

--- a/src/config.h
+++ b/src/config.h
@@ -47,6 +47,7 @@ struct enftun_config
     int table;
     const char** prefixes;
     const char** trusted_ifaces;
+    int allow_ipv4;
 
     int ra_period; /* router advertisement period in ms */
 

--- a/src/filter.c
+++ b/src/filter.c
@@ -20,7 +20,38 @@
 #include "ip.h"
 #include "log.h"
 
+#define IP4_HEADER(hdr, pkt) struct iphdr* hdr = (struct iphdr*) pkt->data
 #define IP6_HEADER(hdr, pkt) struct ip6_hdr* hdr = (struct ip6_hdr*) pkt->data
+
+int
+enftun_is_ipv4(struct enftun_packet* pkt)
+{
+    IP4_HEADER(hdr, pkt);
+
+    if (pkt->size < sizeof(struct iphdr))
+      {
+        enftun_log_debug("enftun_is_ipv4: packet smaller than IPv4 header (%d < %d)\n",
+                         pkt->size, sizeof(struct iphdr));
+        return 0;
+      }
+
+    if (hdr->version != IPVERSION)
+      {
+        enftun_log_debug("enftun_is_ipv4: header version is not 4 (%d != %d)\n",
+                         (hdr->version), IPVERSION);
+        return 0;
+      }
+
+    if (ntohs(hdr->tot_len) != pkt->size)
+    {
+        enftun_log_debug("enftun_is_ipv4: payload length does not match "
+                         "received (%d != %d)\n",
+                         ntohs(hdr->tot_len), pkt->size);
+        return 0;
+    }
+
+    return 1;
+}
 
 int
 enftun_is_ipv6(struct enftun_packet* pkt)

--- a/src/filter.c
+++ b/src/filter.c
@@ -29,18 +29,10 @@ enftun_is_ipv4(struct enftun_packet* pkt)
     IP4_HEADER(hdr, pkt);
 
     if (pkt->size < sizeof(struct iphdr))
-      {
-        enftun_log_debug("enftun_is_ipv4: packet smaller than IPv4 header (%d < %d)\n",
-                         pkt->size, sizeof(struct iphdr));
         return 0;
-      }
 
     if (hdr->version != IPVERSION)
-      {
-        enftun_log_debug("enftun_is_ipv4: header version is not 4 (%d != %d)\n",
-                         (hdr->version), IPVERSION);
         return 0;
-      }
 
     if (ntohs(hdr->tot_len) != pkt->size)
     {
@@ -59,19 +51,10 @@ enftun_is_ipv6(struct enftun_packet* pkt)
     IP6_HEADER(hdr, pkt);
 
     if (pkt->size < sizeof(struct ip6_hdr))
-    {
-        enftun_log_debug(
-            "enftun_is_ipv6: packet smaller than IPv6 header (%d < %d)\n",
-            pkt->size, sizeof(struct ip6_hdr));
         return 0;
-    }
 
     if ((hdr->ip6_vfc & IPV6_VERSION_MASK) != IPV6_VERSION)
-    {
-        enftun_log_debug("enftun_is_ipv6: header version is not 6 (%d != %d)\n",
-                         (hdr->ip6_vfc >> 4), 6);
         return 0;
-    }
 
     if (ntohs(hdr->ip6_plen) != pkt->size - sizeof(*hdr))
     {

--- a/src/filter.h
+++ b/src/filter.h
@@ -25,6 +25,9 @@
 #include "packet.h"
 
 int
+enftun_is_ipv4(struct enftun_packet* pkt);
+
+int
 enftun_is_ipv6(struct enftun_packet* pkt);
 
 int

--- a/src/ip.h
+++ b/src/ip.h
@@ -22,6 +22,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include <netinet/ip.h>
 #include <netinet/ip6.h>
 #include <netinet/udp.h>
 

--- a/test/test.conf
+++ b/test/test.conf
@@ -57,6 +57,9 @@ route : {
   # for these interfaces will be allowed to bypass the tunnel.
   #
   # trusted_interfaces = [ ]
+
+  # If set to true, IPv4 packets will be allowed through the tunnel.
+  allow_ipv4 = true
 }
 
 # Identity settings


### PR DESCRIPTION
This series introduces a new config option `route.allow_ipv4`. If set to `true` (default is `false`), IPv4 packets are allowed through the tunnel.  Unlike the IPv6 src/dst address checks, no validations are performed on the IPv4 packets.

No explicit IPv4 support is added to the `enftun-setup` script.   The user must arrange to set an IPv4 address on the interface and configure routing appropriately.

Resolves #132 
