### PR TITLE
xtt: Update to new XTT API for certificates.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(BUILD_XTT)
     add_definitions(-DUSE_XTT)
     find_package(sodium REQUIRED QUIET 1.0.11)
     find_package(TSS2 REQUIRED QUIET)
-    find_package(xtt COMPONENTS tpm REQUIRED QUIET 0.11.0)
+    find_package(xtt COMPONENTS tpm REQUIRED QUIET 0.12.0)
 endif()
 
 if(BUILD_TPM)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo apt-get install enftun
 * [OpenSSL]() (version 1.1.0 or higher)
 * [LibUV]() (version 1.9 or higher)
 * [LibConfig]() (version 1.5 or higher)
-* [xtt](https://github.com/xaptum/xtt) (version 0.11.0 or higher)
+* [xtt](https://github.com/xaptum/xtt) (version 0.12.0 or higher)
   * If building with XTT and TPM support
 * [LibJansson]()
   * If building with keygen support

--- a/src/xtt.c
+++ b/src/xtt.c
@@ -564,17 +564,17 @@ save_credentials(struct xtt_client_handshake_context* ctx,
 
     // 3) Save longterm keypair as X509 certificate
     //  and PEM-encoded TPM-loadable private key blob
-    unsigned char cert_buf[XTT_X509_CERTIFICATE_LENGTH] = {0};
-    if (0 != xtt_x509_from_ecdsap256_TPM(&my_longterm_key,
-                                         &ctx->longterm_private_key_tpm,
-                                         tpm_ctx->tcti_context, &my_assigned_id,
-                                         cert_buf, sizeof(cert_buf)))
+    unsigned char cert_buf[XTT_X509_CERTIFICATE_MAX_LENGTH] = {0};
+    size_t cert_len                                         = sizeof(cert_buf);
+    if (0 != xtt_x509_from_ecdsap256_TPM(
+                 &my_longterm_key, &ctx->longterm_private_key_tpm,
+                 tpm_ctx->tcti_context, &my_assigned_id, cert_buf, &cert_len))
     {
         enftun_log_error("Error creating X509 certificate\n");
         return CERT_CREATION_ERROR;
     }
-    write_ret = xtt_save_to_file(cert_buf, sizeof(cert_buf),
-                                 longterm_cert_out_file, 0644);
+    write_ret =
+        xtt_save_to_file(cert_buf, cert_len, longterm_cert_out_file, 0644);
     if (write_ret < 0)
     {
         enftun_log_error("Error saving X509 certificate\n");


### PR DESCRIPTION
The xtt project was recently updated to fix a bug with its certificate generation (cf. [xtt#124](https://github.com/xaptum/xtt/pull/124)). That change altered the public API.

This PR updates this project's usage of xtt to work with the new API (and bumps the version requirement for xtt)