### PR TITLE
heartbeat: do not send a heartbeat after each received packet

### DIFF
--- a/src/heartbeat.h
+++ b/src/heartbeat.h
@@ -37,21 +37,24 @@ struct enftun_heartbeat
     const struct in6_addr* source_addr;
     const struct in6_addr* dest_addr;
 
-    struct enftun_packet req_pkt;
-    struct enftun_crb req_crb;
+    enftun_heartbeat_timeout timeout_cb;
+    void* data; // data for timeout callback
 
-    uv_timer_t req_timer;
-    int req_period;
+    // Request timer
+    uv_timer_t request_timer;
+    int request_period;
 
+    struct enftun_packet request_pkt;
+
+    struct enftun_crb request_crb;
+    bool request_scheduled;
+    bool request_sending;
+
+    // Reply timer
     uv_timer_t reply_timer;
     int reply_timeout;
 
-    bool req_scheduled;
-    bool req_sending;
-    bool req_inflight;
-
-    enftun_heartbeat_timeout timeout_cb;
-    void* data; // data for timeout callback
+    bool awaiting_reply;
 };
 
 void


### PR DESCRIPTION
The previous heartbeat implementation contained a bug that caused a
new heartbeat ping to be sent after each received packet.